### PR TITLE
Update monitorstyle.css

### DIFF
--- a/css/monitorstyle.css
+++ b/css/monitorstyle.css
@@ -12,6 +12,17 @@ html {
 }
 
 
+/*.dark-theme{
+  height: 100%;
+  background: radial-gradient(ellipse at bottom, #1b2735 0%, #090a0f 100%);
+  overflow: hidden;
+}*/
+
+.light-theme {
+  height: 100%;
+  background: lightskyblue;
+}
+
 
 #stars {
   width: 1px;


### PR DESCRIPTION
added the .dark-theme and .light-theme classes to make the dark/light theme button work. if any changes to font or anything else needs to be made in the other pages please include in here. the .dark-theme is commented out on purpose, it's not really needed because all the dark mode features are already coded in the default settings. this code can also be copy and paste.